### PR TITLE
Print warning and exit when config file doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/
 .idea/
 tmp/
 config.json
+cmake-build-debug/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <templatebot/templatebot.h>
 #include <sstream>
-#define fs std::filesystem
+namespace fs = std::filesystem;
 
 /* When you invite the bot, be sure to invite it with the
  * scopes 'bot' and 'applications.commands', e.g.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ using json = nlohmann::json;
 int main(int argc, char const *argv[])
 {
     if(!fs::exists("../config.json")) {
-        std::cout << canonical(fs::path("..")).append("config.json") << " does not exist!" << std::endl;
+        std::cout << canonical(fs::path("..")).append("config.json").string() << " does not exist!" << std::endl;
         return 1;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,11 @@ using json = nlohmann::json;
 
 int main(int argc, char const *argv[])
 {
+    if(!std::filesystem::exists("../config.json")) {
+        std::cout << "../config.json does not exist!" << std::endl;
+        return 1;
+    }
+
     json configdocument;
     std::ifstream configfile("../config.json");
     configfile >> configdocument;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <templatebot/templatebot.h>
 #include <sstream>
+#define fs std::filesystem
 
 /* When you invite the bot, be sure to invite it with the
  * scopes 'bot' and 'applications.commands', e.g.
@@ -10,8 +11,8 @@ using json = nlohmann::json;
 
 int main(int argc, char const *argv[])
 {
-    if(!std::filesystem::exists("../config.json")) {
-        std::cout << "../config.json does not exist!" << std::endl;
+    if(!fs::exists("../config.json")) {
+        std::cout << canonical(fs::path("..")).append("config.json") << " does not exist!" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
Added a little bit of code to check that the config file doesn't exist. This prevents a crash when the config doesn't exist.

I've also added cmake-build-debug to the gitignore, since that directory contains build output when built from CLion.