### PR TITLE
Fixed typos, removed unnecessary stuff to stay up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CMake template for a simple [D++](https://dpp.dev) bot. This template assumes th
     cmake ..
     make -j
 
-If DPP is installed in a different location you can specify the root directory to look in while running cmake 
+If DPP is installed in a different location, you can specify the root directory to look in while running cmake 
 
     cmake .. -DDPP_ROOT_DIR=<your-path>
 

--- a/include/templatebot/templatebot.h
+++ b/include/templatebot/templatebot.h
@@ -1,6 +1,5 @@
 #pragma once
 
 #include <dpp/dpp.h>
-#include <dpp/nlohmann/json.hpp>
 
 // Place any forward declarations here

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,15 +6,13 @@
  * https://discord.com/oauth2/authorize?client_id=940762342495518720&scope=bot+applications.commands&permissions=139586816064
  */
 
-using json = nlohmann::json;
-
 int main(int argc, char const *argv[])
 {
-    json configdocument;
+    dpp::json configdocument;
     std::ifstream configfile("../config.json");
     configfile >> configdocument;
 
-    /* Setup the bot */
+    /* Set up the bot */
     dpp::cluster bot(configdocument["token"]);
 
     /* Output simple log messages to stdout */
@@ -29,7 +27,7 @@ int main(int argc, char const *argv[])
 
     /* Register slash command here in on_ready */
     bot.on_ready([&bot](const dpp::ready_t& event) {
-        /* Wrap command registration in run_once to make sure it doesnt run on every full reconnection */
+        /* Wrap command registration in run_once to make sure it doesn't run on every full reconnection */
         if (dpp::run_once<struct register_bot_commands>()) {
             bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
         }


### PR DESCRIPTION
Since `nlohmann/json.hpp` is included in `dpp/dpp.h` now, there's no need to include json separately. Also fixed typos in comments and added punctuation in readme.