### PR TITLE
Fixed a deprecation warning and a compilation error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "DPP"]
+	path = DPP
+	url = https://github.com/brainboxdotcc/DPP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.15)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(BOT_NAME "templatebot")
@@ -50,19 +50,19 @@ if (DPP_FOUND)
     target_link_libraries(${BOT_NAME} ${DPP_LIBRARIES})
     target_include_directories(${BOT_NAME} PUBLIC ${DPP_INCLUDE_DIR})
 else()
-    message(WARNING "Could not find DPP install. Building from source instead.")
-    option(DPP_BUILD_TEST "" OFF)
-    include(FetchContent)
-
-    FetchContent_Declare(
-            libdpp
-            GIT_REPOSITORY https://github.com/brainboxdotcc/DPP.git
-            GIT_TAG master)
-
-    FetchContent_GetProperties(libdpp)
-    if(NOT libdpp_POPULATED)
-        FetchContent_MakeAvailable(libdpp)
-    endif()
-
-    target_link_libraries(${BOT_NAME} dpp)
+	find_package(Git)
+	message(WARNING "Could not find DPP install. Building from source instead.")
+	if (GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+				RESULT_VARIABLE RESULT)
+		if (NOT RESULT EQUAL 0)
+			message(FATAL_ERROR "Failed to update the D++ submodule. Code: ${RESULT}.")
+		else()
+			add_subdirectory(DPP)
+			target_link_libraries(${BOT_NAME} dpp)
+		endif()
+	else()
+		message(FATAL_ERROR "Failed to find the git executable. Can't update the D++ submodule.")
+	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,14 +61,7 @@ else()
 
     FetchContent_GetProperties(libdpp)
     if(NOT libdpp_POPULATED)
-        FetchContent_Populate(libdpp)
-        target_include_directories(${BOT_NAME} PUBLIC
-            ${libdpp_SOURCE_DIR}/include
-        )
-        add_subdirectory(
-            ${libdpp_SOURCE_DIR}
-            ${libdpp_BINARY_DIR}
-            EXCLUDE_FROM_ALL)
+        FetchContent_MakeAvailable(libdpp)
     endif()
 
     target_link_libraries(${BOT_NAME} dpp)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <templatebot/templatebot.h>
-#include <sstream>
 
 /* When you invite the bot, be sure to invite it with the
  * scopes 'bot' and 'applications.commands', e.g.
@@ -8,14 +7,15 @@
 
 using json = nlohmann::json;
 
-int main(int argc, char const *argv[])
-{
+int main(int argc, char const *argv[]) {
     json configdocument;
     std::ifstream configfile("../config.json");
     configfile >> configdocument;
 
-    /* Setup the bot */
-    dpp::cluster bot(configdocument["token"]);
+    const std::string BOT_TOKEN = configdocument["token"];
+
+    /* Set up the bot */
+    dpp::cluster bot(BOT_TOKEN);
 
     /* Output simple log messages to stdout */
     bot.on_log(dpp::utility::cout_logger());
@@ -29,7 +29,7 @@ int main(int argc, char const *argv[])
 
     /* Register slash command here in on_ready */
     bot.on_ready([&bot](const dpp::ready_t& event) {
-        /* Wrap command registration in run_once to make sure it doesnt run on every full reconnection */
+        /* Wrap command registration in run_once to make sure it doesn't run on every full reconnection */
         if (dpp::run_once<struct register_bot_commands>()) {
             bot.global_command_create(dpp::slashcommand("ping", "Ping pong!", bot.me.id));
         }


### PR DESCRIPTION
Me being on g++-14, Debian 13 might be important

When I tried compiling the bot, I got this error:

```
/home/henonicks/ppstuff/templatebot/src/main.cpp: In function ‘int main(int, const char**)’:
/home/henonicks/ppstuff/templatebot/src/main.cpp:18:45: error: call of overloaded ‘cluster(nlohmann::json_abi_v3_11_2::basic_json<>::value_type&)’ is ambiguous
   18 |     dpp::cluster bot(configdocument["token"]);
      |
```

So I made a constant `std::string` to store the token.
Also, it seems that `FetchContent_Populate` is deprecated and CMake seems to be planning on removing it:
```
Calling FetchContent_Populate(libdpp) is deprecated, call
FetchContent_MakeAvailable(libdpp) instead.  Policy CMP0169 can be set to
OLD to allow FetchContent_Populate(libdpp) to be called directly for now,
but the ability to call it with declared details will be removed completely
in a future version.
```
So I replaced it with `MakeAvailable`. Remember how I didn't test the change properly the last time? Well, I compiled the template to properly test this time! After I uninstalled D++ from my machine, of course.

So, after my change, the deprecation warning is gone, and so is the compilation error. And the spelling errors in the comments. I'm taking another crack at fixing them.